### PR TITLE
Update to try-o-rama 0.1.3-beta.2

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@holochain/diorama": "^0.2.0-rc.1",
+    "@holochain/try-o-rama": "0.1.3-beta.2",
     "json3": "*",
     "faucet": "0.0.1",
     "sleep": "^6.0.0",


### PR DESCRIPTION
This PR updates this repo's tests to the latest try-o-ram (0.1.3-beta.2)