### PR TITLE
pass in type Address instead of ed25519_dalek::PublicKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,15 +475,15 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.0.50-alpha4"
+version = "0.0.51-alpha1"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_core_types 0.0.50-alpha4",
+ "holochain_core_types 0.0.51-alpha1",
  "holochain_json_api 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_derive 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_wasm_utils 0.0.50-alpha4",
+ "holochain_wasm_utils 0.0.51-alpha1",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -494,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "hdk_proc_macros"
-version = "0.0.50-alpha4"
+version = "0.0.51-alpha1"
 dependencies = [
- "hdk 0.0.50-alpha4",
+ "hdk 0.0.51-alpha1",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_core_types"
-version = "0.0.50-alpha4"
+version = "0.0.51-alpha1"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -523,7 +523,7 @@ dependencies = [
  "hcid 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_api 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_derive 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_locksmith 0.0.50-alpha4",
+ "holochain_locksmith 0.0.51-alpha1",
  "holochain_logging 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_locksmith"
-version = "0.0.50-alpha4"
+version = "0.0.51-alpha1"
 dependencies = [
  "backtrace 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_utils"
-version = "0.0.50-alpha4"
+version = "0.0.51-alpha1"
 dependencies = [
- "holochain_core_types 0.0.50-alpha4",
+ "holochain_core_types 0.0.51-alpha1",
  "holochain_json_api 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_derive 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1243,11 +1243,11 @@ dependencies = [
  "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hcid 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "hdk 0.0.50-alpha4",
- "hdk_proc_macros 0.0.50-alpha4",
+ "hdk 0.0.51-alpha1",
+ "hdk_proc_macros 0.0.51-alpha1",
  "holochain_json_derive 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_wasm_utils 0.0.50-alpha4",
+ "holochain_wasm_utils 0.0.51-alpha1",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/test/bridging.js
+++ b/test/bridging.js
@@ -128,11 +128,11 @@ scenario('testing invoice generation', async (s, t) => {
 
   // Check if an invoice should be generated (passed threshold)
   var invoice = await conductor.callSync(serv, "service", "generate_invoice", {})
-  t.deepEqual(invoice, { Ok: 'QmR4iXQHygR9NCbMJJEA1UYqXZNJuPfcTqdZW7wKhXSzYR' })
+  t.deepEqual(invoice, { Ok: 'QmSFBTFg4ayVHJjw7ar9SkJYmmT1uK79zoHqz2YP3PmaLa' })
 
   // Now we should have an invoice
   invoices = await conductor.callSync(serv, "service", "list_unpaid_invoices", {})
-  t.deepEqual(invoices, { Ok: [ 'QmR4iXQHygR9NCbMJJEA1UYqXZNJuPfcTqdZW7wKhXSzYR' ] })
+  t.deepEqual(invoices, { Ok: [ 'QmSFBTFg4ayVHJjw7ar9SkJYmmT1uK79zoHqz2YP3PmaLa' ] })
 
   // Check that the Invoice notes indicate the source and details of the invoice,
   const earnings = await conductor.callSync(fuel, "transactions", "list_transactions", {

--- a/zomes/service/code/src/lib.rs
+++ b/zomes/service/code/src/lib.rs
@@ -84,7 +84,7 @@ pub mod service {
     /// The `host_id` *must* be that of the committing host for validation to succeed.
     #[zome_fn("hc_public")]
     fn log_request(
-        agent_id: validate::Agent,
+        agent_id: Address, //validate::Agent,
         request: request::RequestPayload,
         request_signature: validate::AgentSignature,
     ) -> ZomeApiResult<Address> {
@@ -113,7 +113,7 @@ pub mod service {
 
     #[zome_fn("hc_public")]
     fn log_service(
-        agent_id: validate::Agent,
+        agent_id: Address, //validate::Agent,
         response_commit: Address,
         confirmation: servicelog::Confirmation,
         confirmation_signature: validate::AgentSignature,

--- a/zomes/service/code/src/request.rs
+++ b/zomes/service/code/src/request.rs
@@ -33,7 +33,7 @@ pub struct ClientRequest {
 #[derive(Debug, Clone, DefaultJson, Serialize, Deserialize)]
 pub struct RequestPayload {
     call_spec: CallSpec,
-    host_id: Agent,
+    host_id: Address,
     timestamp: Iso8601,
 }
 


### PR DESCRIPTION
The current implementation of `chaperone` and `holo-envoy` we are passing a `AgentID` in the hcid ('hcs0') codec format.

But the implementation of servicelogger expected it to pass a `ed25519_dalek::PublicKey` i.e.
```
pub struct Agent(ed25519_dalek::PublicKey);
```

### Changes: 

The DNA has been updated to accept the `agent_id` in the type `hdk::Address` and during validation of the signature it is converted to the  `ed25519_dalek::PublicKey` for verification.